### PR TITLE
fix: update tool registration for fastmcp 2.8

### DIFF
--- a/mcp_tools/__init__.py
+++ b/mcp_tools/__init__.py
@@ -1,12 +1,15 @@
+"""Tool registry for the Quotation Generator."""
+
 from fastmcp import FastMCP
 
-from .generate_quote import GenerateQuoteTool
+from .generate_quote import register as register_generate_quote
 
 
 mcp = FastMCP(
     name="Quotation Generator",
-    description="Uma tool que orquestra a geração de orçamentos para clientes.",
+    instructions="Uma tool que orquestra a geração de orçamentos para clientes.",
 )
-mcp.add_tool(GenerateQuoteTool())
 
-__all__ = ["mcp", "GenerateQuoteTool"]
+register_generate_quote(mcp)
+
+__all__ = ["mcp"]

--- a/mcp_tools/generate_quote.py
+++ b/mcp_tools/generate_quote.py
@@ -1,25 +1,37 @@
-from fastmcp import BaseTool
-from pydantic import BaseModel
+"""Generate quotation document tool."""
+
 from typing import List, Optional
+
+from fastmcp import FastMCP
 
 from services.doc_service import BudgetItem, BudgetRequest, generate_document
 
 
-class GenerateQuoteInput(BaseModel):
-    cliente: Optional[str] = None
-    responsavel: Optional[str] = None
-    proposta_comercial: Optional[str] = None
-    email: Optional[str] = None
-    data: Optional[str] = None
-    assunto: Optional[str] = None
-    itens: List[BudgetItem]
+def register(mcp: FastMCP) -> None:
+    """Register the ``generate_quote`` tool with the given server."""
 
+    @mcp.tool(name="generate_quote", description="Cria um documento de orçamento em DOCX")
+    def generate_quote(
+        cliente: Optional[str] = None,
+        responsavel: Optional[str] = None,
+        proposta_comercial: Optional[str] = None,
+        email: Optional[str] = None,
+        data: Optional[str] = None,
+        assunto: Optional[str] = None,
+        itens: List[BudgetItem] = [],
+    ) -> str:
+        """Create a DOCX quote and return the relative file path."""
 
-class GenerateQuoteTool(BaseTool):
-    name = "generate_quote"
-    description = "Cria um documento de orçamento em DOCX"
-    input_model = GenerateQuoteInput
-
-    def run(self, data: GenerateQuoteInput) -> str:
-        req = BudgetRequest(**data.model_dump())
+        req = BudgetRequest(
+            cliente=cliente,
+            responsavel=responsavel,
+            proposta_comercial=proposta_comercial,
+            email=email,
+            data=data,
+            assunto=assunto,
+            itens=itens,
+        )
         return generate_document(req)
+
+
+__all__ = ["register"]


### PR DESCRIPTION
## Summary
- adapt `mcp_tools` to new FastMCP API
- register `generate_quote` with a function rather than `BaseTool`

## Testing
- `pytest -q`
- `python mcp_server.py` (manual run)


------
https://chatgpt.com/codex/tasks/task_e_684df6ef8160832d8be3fb08cd87e965